### PR TITLE
updates setup-node action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Setup Node.js environment
-        uses: actions/setup-node@v1.4.2
+        uses: actions/setup-node@v2
 
       - name: Checkout to the repository
         uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Setup Node.js environment
-        uses: actions/setup-node@v1.4.2
+        uses: actions/setup-node@v2
 
       - name: Checkout to the repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Updates node version in setup-node action thus fixing the error where Github-hosted runner is unable to set up the node environment